### PR TITLE
proposal: save static memory 

### DIFF
--- a/src/ESP8266SAM.cpp
+++ b/src/ESP8266SAM.cpp
@@ -42,14 +42,14 @@ void ESP8266SAM::OutputByte(unsigned char b)
   while (!output->ConsumeSample(sample)) yield();
 }
   
-void ESP8266SAM::Say(AudioOutput *out, const char *str)
+bool ESP8266SAM::Say(AudioOutput *out, const char *str)
 {
-  if (!str || strlen(str)>254) return; // Only can speak up to 1 page worth of data...
+  if (!str || strlen(str)>254) return false; // Only can speak up to 1 page worth of data...
   samdata = new SamData;
   if (samdata == nullptr)
   {
       // allocation failed!
-      return;
+      return false;
   }
   
   // These are fixed by the synthesis routines
@@ -76,7 +76,7 @@ void ESP8266SAM::Say(AudioOutput *out, const char *str)
     strncat(input, "\x9b", 255);
   } else {
     strncat(input, "[", 255);
-    if (!TextToPhonemes(input)) return; // ERROR
+    if (!TextToPhonemes(input)) return false; // ERROR
   }
 
   // Say it!
@@ -84,6 +84,7 @@ void ESP8266SAM::Say(AudioOutput *out, const char *str)
   SetInput(input);
   SAMMain(OutputByteCallback, (void*)this);
   delete samdata;
+  return true;
 }
 
 void ESP8266SAM::SetVoice(enum SAMVoice voice)

--- a/src/ESP8266SAM.cpp
+++ b/src/ESP8266SAM.cpp
@@ -21,6 +21,11 @@
 
 #include "reciter.h"
 #include "sam.h"
+#include "SamData.h"
+
+#ifdef SAMDATA
+SamData* samdata;
+#endif
 
 // Thunk from C to C++ with a this-> pointer
 void ESP8266SAM::OutputByteCallback(void *cbdata, unsigned char b)
@@ -42,6 +47,14 @@ void ESP8266SAM::OutputByte(unsigned char b)
 void ESP8266SAM::Say(AudioOutput *out, const char *str)
 {
   if (!str || strlen(str)>254) return; // Only can speak up to 1 page worth of data...
+#ifdef SAMDATA
+  samdata = new SamData;
+  if (samdata == nullptr)
+  {
+      // allocation failed!
+      return;
+  }
+#endif
   
   // These are fixed by the synthesis routines
   out->SetRate(22050);
@@ -74,6 +87,9 @@ void ESP8266SAM::Say(AudioOutput *out, const char *str)
   output = out;
   SetInput(input);
   SAMMain(OutputByteCallback, (void*)this);
+#ifdef SAMDATA
+  delete samdata;
+#endif
 }
 
 void ESP8266SAM::SetVoice(enum SAMVoice voice)

--- a/src/ESP8266SAM.cpp
+++ b/src/ESP8266SAM.cpp
@@ -23,9 +23,7 @@
 #include "sam.h"
 #include "SamData.h"
 
-#ifdef SAMDATA
 SamData* samdata;
-#endif
 
 // Thunk from C to C++ with a this-> pointer
 void ESP8266SAM::OutputByteCallback(void *cbdata, unsigned char b)
@@ -47,14 +45,12 @@ void ESP8266SAM::OutputByte(unsigned char b)
 void ESP8266SAM::Say(AudioOutput *out, const char *str)
 {
   if (!str || strlen(str)>254) return; // Only can speak up to 1 page worth of data...
-#ifdef SAMDATA
   samdata = new SamData;
   if (samdata == nullptr)
   {
       // allocation failed!
       return;
   }
-#endif
   
   // These are fixed by the synthesis routines
   out->SetRate(22050);
@@ -87,9 +83,7 @@ void ESP8266SAM::Say(AudioOutput *out, const char *str)
   output = out;
   SetInput(input);
   SAMMain(OutputByteCallback, (void*)this);
-#ifdef SAMDATA
   delete samdata;
-#endif
 }
 
 void ESP8266SAM::SetVoice(enum SAMVoice voice)

--- a/src/ESP8266SAM.h
+++ b/src/ESP8266SAM.h
@@ -49,12 +49,12 @@ public:
   void SetThroat(uint8_t val) { throat = val; }
   void SetSpeed(uint8_t val) { speed = val; }
 
-  void Say(AudioOutput *out, const char *str);
-  void Say_P(AudioOutput *out, const char *str) {
+  bool Say(AudioOutput *out, const char *str);
+  bool Say_P(AudioOutput *out, const char *str) {
     char ram[256];
     strncpy_P(ram, str, 256);
     ram[255] = 0;
-    Say(out, ram);
+    return Say(out, ram);
   };
 
 private:

--- a/src/SamData.h
+++ b/src/SamData.h
@@ -14,7 +14,6 @@ extern "C" {
 
 #define SAMDATA
 
-#ifdef SAMDATA
 typedef struct s_samdata
 {
     struct render
@@ -28,6 +27,9 @@ typedef struct s_samdata
         unsigned char amplitude3[256];
         unsigned char sampledConsonantFlag[256]; // tab44800
     } render;
+    struct reciter {
+        unsigned char inputtemp[256];
+    } reciter;
     struct sam
     {
         char input[256]; //tab39445
@@ -37,13 +39,10 @@ typedef struct s_samdata
         unsigned char phonemeIndexOutput[60]; //tab47296
         unsigned char stressOutput[60]; //tab47365
         unsigned char phonemeLengthOutput[60]; //tab47416
-
     } sam;
 } SamData;
 
 extern SamData* samdata;
-
-#endif
 
 #ifdef __cplusplus
 }
@@ -51,4 +50,4 @@ extern SamData* samdata;
 
 
 
-#endif /* LIBRARIES_ESP8266SAM_SRC_SAMDATA_H_ */
+#endif /* SAMDATA_H_ */

--- a/src/SamData.h
+++ b/src/SamData.h
@@ -1,0 +1,54 @@
+/*
+ * dataspace.h
+ *
+ *  Created on: Feb 24, 2019
+ *      Author: chris.l
+ */
+
+#ifndef SAMDATA_H_
+#define SAMDATA_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SAMDATA
+
+#ifdef SAMDATA
+typedef struct s_samdata
+{
+    struct render
+    {
+        unsigned char pitches[256]; // tab43008
+        unsigned char frequency1[256];
+        unsigned char frequency2[256];
+        unsigned char frequency3[256];
+        unsigned char amplitude1[256];
+        unsigned char amplitude2[256];
+        unsigned char amplitude3[256];
+        unsigned char sampledConsonantFlag[256]; // tab44800
+    } render;
+    struct sam
+    {
+        char input[256]; //tab39445
+        unsigned char stress[256]; //numbers from 0 to 8
+        unsigned char phonemeLength[256]; //tab40160
+        unsigned char phonemeindex[256];
+        unsigned char phonemeIndexOutput[60]; //tab47296
+        unsigned char stressOutput[60]; //tab47365
+        unsigned char phonemeLengthOutput[60]; //tab47416
+
+    } sam;
+} SamData;
+
+extern SamData* samdata;
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+
+#endif /* LIBRARIES_ESP8266SAM_SRC_SAMDATA_H_ */

--- a/src/reciter.c
+++ b/src/reciter.c
@@ -3,11 +3,12 @@
 #include "reciter.h"
 #include "ReciterTabs.h"
 #include "debug.h"
+#include "SamData.h"
 
 unsigned char A, X, Y;
 //extern int debug;
 
-static unsigned char inputtemp[256];   // secure copy of input tab36096
+#define inputtemp (samdata->reciter.inputtemp)
 
 void Code37055(unsigned char mem59)
 {

--- a/src/render.c
+++ b/src/render.c
@@ -27,7 +27,6 @@ extern unsigned char speed;
 extern unsigned char pitch;
 extern int singmode;
 
-#ifdef SAMDATA
 #define phonemeIndexOutput (samdata->sam.phonemeIndexOutput)
 #define stressOutput (samdata->sam.stressOutput)
 #define phonemeLengthOutput (samdata->sam.phonemeLengthOutput)
@@ -39,23 +38,6 @@ extern int singmode;
 #define amplitude2 (samdata->render.amplitude2)
 #define amplitude3 (samdata->render.amplitude3)
 #define sampledConsonantFlag (samdata->render.sampledConsonantFlag)
-#else
-extern unsigned char phonemeIndexOutput[60]; //tab47296
-extern unsigned char stressOutput[60]; //tab47365
-extern unsigned char phonemeLengthOutput[60]; //tab47416
-
-unsigned char pitches[256]; // tab43008
-
-unsigned char frequency1[256];
-unsigned char frequency2[256];
-unsigned char frequency3[256];
-
-unsigned char amplitude1[256];
-unsigned char amplitude2[256];
-unsigned char amplitude3[256];
-
-unsigned char sampledConsonantFlag[256]; // tab44800
-#endif
 
 void AddInflection(unsigned char mem48, unsigned char phase1);
 unsigned char trans(unsigned char mem39212, unsigned char mem39213);

--- a/src/render.c
+++ b/src/render.c
@@ -8,6 +8,7 @@
 #include "debug.h"
 //extern int debug;
 #include <pgmspace.h>
+#include "SamData.h"
 
 unsigned char wait1 = 7;
 unsigned char wait2 = 6;
@@ -26,7 +27,19 @@ extern unsigned char speed;
 extern unsigned char pitch;
 extern int singmode;
 
-
+#ifdef SAMDATA
+#define phonemeIndexOutput (samdata->sam.phonemeIndexOutput)
+#define stressOutput (samdata->sam.stressOutput)
+#define phonemeLengthOutput (samdata->sam.phonemeLengthOutput)
+#define pitches    (samdata->render.pitches)
+#define frequency1 (samdata->render.frequency1)
+#define frequency2 (samdata->render.frequency2)
+#define frequency3 (samdata->render.frequency3)
+#define amplitude1 (samdata->render.amplitude1)
+#define amplitude2 (samdata->render.amplitude2)
+#define amplitude3 (samdata->render.amplitude3)
+#define sampledConsonantFlag (samdata->render.sampledConsonantFlag)
+#else
 extern unsigned char phonemeIndexOutput[60]; //tab47296
 extern unsigned char stressOutput[60]; //tab47365
 extern unsigned char phonemeLengthOutput[60]; //tab47416
@@ -42,7 +55,7 @@ unsigned char amplitude2[256];
 unsigned char amplitude3[256];
 
 unsigned char sampledConsonantFlag[256]; // tab44800
-
+#endif
 
 void AddInflection(unsigned char mem48, unsigned char phase1);
 unsigned char trans(unsigned char mem39212, unsigned char mem39213);

--- a/src/sam.c
+++ b/src/sam.c
@@ -6,8 +6,13 @@
 #include "sam.h"
 #include "render.h"
 #include "SamTabs.h"
+#include "SamData.h"
 
+#ifdef SAMDATA
+#define input (samdata->sam.input)
+#else
 static char input[256]; //tab39445
+#endif
 //standard sam sound
 unsigned char speed = 72;
 unsigned char pitch = 64;
@@ -30,6 +35,14 @@ unsigned char mem59=0;
 
 static unsigned char A, X, Y;
 
+#ifdef SAMDATA
+#define stress (samdata->sam.stress)
+#define phonemeLength (samdata->sam.phonemeLength)
+#define phonemeindex (samdata->sam.phonemeindex)
+#define phonemeIndexOutput (samdata->sam.phonemeIndexOutput)
+#define stressOutput (samdata->sam.stressOutput)
+#define phonemeLengthOutput (samdata->sam.phonemeLengthOutput)
+#else
 static unsigned char stress[256]; //numbers from 0 to 8
 static unsigned char phonemeLength[256]; //tab40160
 static unsigned char phonemeindex[256];
@@ -37,7 +50,7 @@ static unsigned char phonemeindex[256];
 unsigned char phonemeIndexOutput[60]; //tab47296
 unsigned char stressOutput[60]; //tab47365
 unsigned char phonemeLengthOutput[60]; //tab47416
-
+#endif
 
 
 

--- a/src/sam.c
+++ b/src/sam.c
@@ -8,11 +8,6 @@
 #include "SamTabs.h"
 #include "SamData.h"
 
-#ifdef SAMDATA
-#define input (samdata->sam.input)
-#else
-static char input[256]; //tab39445
-#endif
 //standard sam sound
 unsigned char speed = 72;
 unsigned char pitch = 64;
@@ -35,22 +30,13 @@ unsigned char mem59=0;
 
 static unsigned char A, X, Y;
 
-#ifdef SAMDATA
+#define input (samdata->sam.input)
 #define stress (samdata->sam.stress)
 #define phonemeLength (samdata->sam.phonemeLength)
 #define phonemeindex (samdata->sam.phonemeindex)
 #define phonemeIndexOutput (samdata->sam.phonemeIndexOutput)
 #define stressOutput (samdata->sam.stressOutput)
 #define phonemeLengthOutput (samdata->sam.phonemeLengthOutput)
-#else
-static unsigned char stress[256]; //numbers from 0 to 8
-static unsigned char phonemeLength[256]; //tab40160
-static unsigned char phonemeindex[256];
-
-unsigned char phonemeIndexOutput[60]; //tab47296
-unsigned char stressOutput[60]; //tab47365
-unsigned char phonemeLengthOutput[60]; //tab47416
-#endif
 
 
 


### PR DESCRIPTION
There are many 256 and 60 byte arrays, about 4k in total, that are only used during "say".  On an ESP8266 that uses enough memory to prevent using SSL.  This, hack at the moment, shows that one can dynamically allocate these when needed and keep memory free for https requests as long as they are not both used at the same time.  Thoughts?
